### PR TITLE
深圳市万屏时代科技有限公司，强制996，迟到早退乐捐（罚款）。

### DIFF
--- a/blacklist/README.md
+++ b/blacklist/README.md
@@ -262,3 +262,4 @@
 |北京|澎思智能|2019年7月|996|[微信截图](https://github.com/wangleipes/996.ICU/blob/master/blacklist/img/%E6%BE%8E%E6%80%9D.png)|
 |南京|[中设设计集团子公司纬信工程咨询公司](http://www.js-wx.com.cn/lxwm.asp)|自公司成立|领导明令8106，工作前三年无年假|[群聊截图1](img/道桥部群聊截图.jpg)，[群聊截图2](img/道桥部群聊截图1.jpg)，[群聊截图3](img/道桥部群聊截图2.jpg)，[签到表7.31](img/签到表7.31.jpg)，[签到表8.1](img/签到表8.1.jpg)|
 |北京|畅捷通信息技术股份有限公司|2019年8月,9月|领导明令996, 每周二四固定加班|[邮件截图](img/畅捷通-996-mail-m.jpg)，[群聊截图](img/畅捷通-996-m.jpg)|
+|深圳|深圳市万屏时代科技有限公司|2020年4月|强制996，迟到早退罚款|[工作群截图](https://i.loli.net/2020/04/27/MwKVDCpH1J59A4c.jpg)，[钉钉考情截图](https://i.loli.net/2020/04/29/sqTSyMJjhfrBbae.jpg)|


### PR DESCRIPTION
深圳市万屏时代科技有限公司，强制996，迟到早退乐捐（罚款）。钉钉考勤和微信群通告截图为证。实锤违法，剥削。